### PR TITLE
I3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport (>= 5)
       aws-sdk-s3
       aws-sdk-sqs
+      httparty
       marcel
       mime-types
       mini_magick
@@ -50,6 +51,9 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     e2mmap (0.1.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     hydra-file_characterization (1.2.0)
       activesupport (>= 3.0.0)
     i18n (1.12.0)
@@ -65,7 +69,9 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
+    mini_mime (1.1.2)
     minitest (5.18.0)
+    multi_xml (0.6.0)
     nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
     parallel (1.22.1)

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc "Generate table of contents for README.md"
 task :doctoc do
-  if `which doctoc`.strip.length.zero?
+  if `which doctoc`.strip.empty?
     $stdout.puts 'Skipping doctoc generation; install via "npm install -g doctoc"'
   else
     $stdout.puts 'Generating table of contents for README.md'

--- a/derivative-rodeo.gemspec
+++ b/derivative-rodeo.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   # NOTE: aws-sdk-sqs could be a rodeo plugin, but for now, it's part of the main show
   spec.add_dependency 'aws-sdk-sqs'
   spec.add_dependency 'activesupport', ">= 5"
+  spec.add_dependency 'httparty'
   spec.add_dependency 'marcel'
   spec.add_dependency 'mime-types'
   spec.add_dependency 'mini_magick'

--- a/lib/derivative/rodeo.rb
+++ b/lib/derivative/rodeo.rb
@@ -26,6 +26,7 @@ require 'derivative/rodeo/process'
 require 'derivative/rodeo/queue_adapters'
 require 'derivative/rodeo/storage_adapters'
 require 'derivative/rodeo/step'
+require 'derivative/rodeo/utilities/url'
 
 # These are the files conceptually lifted from the IIIF Print gem; they are of secondary concern.
 # And will slowly be moved elsewhere.

--- a/lib/derivative/rodeo/arena.rb
+++ b/lib/derivative/rodeo/arena.rb
@@ -130,7 +130,7 @@ module Derivative
         if dry_run?
           extend Rodeo::DryRun.for(method_names: [
                                      :local_assign!,
-                                     :local_demand!,
+                                     :local_demand_path_for!,
                                      :local_exists?,
                                      :local_path,
                                      :local_read,
@@ -258,8 +258,8 @@ module Derivative
       # Delegate the local demand to the given :derivative.  The :derivative knows best.
       #
       # @param derivative [#to_sym]
-      def local_demand!(derivative:)
-        Rodeo.Step(derivative).demand!(manifest: manifest, storage: local_storage)
+      def local_demand_path_for!(derivative:)
+        Rodeo.Step(derivative).demand_path_for!(manifest: manifest, storage: local_storage)
       end
 
       ##

--- a/lib/derivative/rodeo/arena.rb
+++ b/lib/derivative/rodeo/arena.rb
@@ -136,8 +136,8 @@ module Derivative
                                      :local_read,
                                      :local_run_command!,
                                      :remote_exists?,
-                                     :remote_pull!,
-                                     :remote_pull
+                                     :remote_fetch!,
+                                     :remote_fetch
                                    ],
                                    contexts: dry_run_context,
                                    config: config)
@@ -194,7 +194,7 @@ module Derivative
         ).to_json
       end
 
-      delegate :exists?, :assign!, :path, :read, to: :local_storage, prefix: "local"
+      delegate :path_for_shell_commands, :exists?, :assign!, :path, :read, to: :local_storage, prefix: "local"
       delegate :exists?, to: :remote_storage, prefix: "remote"
       delegate :original_filename, :mime_type, :mime_type=, to: :manifest
       delegate :dry_run, :dry_run?, to: :config
@@ -238,9 +238,9 @@ module Derivative
       # @note
       #
       #   Instead of relying on the delegate method and prefix, I want to ensure that the
-      #   {#remote_storage}'s pull method receives the {#local_storage} as the to: keyword.
-      def remote_pull(derivative:)
-        remote_storage.pull(derivative: derivative, to: local_storage)
+      #   {#local_storage}'s fetch!! method receives the {#remote_storage} as the from: keyword.
+      def remote_fetch(derivative:)
+        local_storage.fetch(derivative: derivative, from: remote_storage)
       end
 
       ##
@@ -249,9 +249,9 @@ module Derivative
       # @note
       #
       #   Instead of relying on the delegate method and prefix, I want to ensure that the
-      #   {#remote_storage}'s pull! method receives the {#local_storage} as the to: keyword.
-      def remote_pull!(derivative:)
-        remote_storage.pull!(derivative: derivative, to: local_storage)
+      #   {#local_storage}'s fetch!! method receives the {#remote_storage} as the from: keyword.
+      def remote_fetch!(derivative:)
+        local_storage.fetch!(derivative: derivative, from: remote_storage)
       end
 
       ##

--- a/lib/derivative/rodeo/process.rb
+++ b/lib/derivative/rodeo/process.rb
@@ -36,13 +36,13 @@ module Derivative
 
       attr_reader :derivative, :arena
 
-      delegate :process_next_chain_link_after!, :local_demand_path_for!, :local_exists?, :remote_pull, to: :arena
+      delegate :process_next_chain_link_after!, :local_demand_path_for!, :local_exists?, :remote_fetch, to: :arena
       delegate :generate_for, to: :derivative
 
       # @api private
       def call
         local_exists?(derivative: derivative) ||
-          remote_pull(derivative: derivative) ||
+          remote_fetch(derivative: derivative) ||
           generate_for(arena: arena)
 
         # Will raise an exception if the above failed to put the derivative in the correct local

--- a/lib/derivative/rodeo/process.rb
+++ b/lib/derivative/rodeo/process.rb
@@ -36,7 +36,7 @@ module Derivative
 
       attr_reader :derivative, :arena
 
-      delegate :process_next_chain_link_after!, :local_demand!, :local_exists?, :remote_pull, to: :arena
+      delegate :process_next_chain_link_after!, :local_demand_path_for!, :local_exists?, :remote_pull, to: :arena
       delegate :generate_for, to: :derivative
 
       # @api private
@@ -47,7 +47,7 @@ module Derivative
 
         # Will raise an exception if the above failed to put the derivative in the correct local
         # location.
-        local_demand!(derivative: derivative)
+        local_demand_path_for!(derivative: derivative)
 
         process_next_chain_link_after!(derivative: derivative)
       end

--- a/lib/derivative/rodeo/queue_adapters.rb
+++ b/lib/derivative/rodeo/queue_adapters.rb
@@ -47,5 +47,6 @@ module Derivative
   end
 end
 
-require "derivative/rodeo/queue_adapters/inline_adapter"
 require "derivative/rodeo/queue_adapters/aws_sqs_adapter"
+require "derivative/rodeo/queue_adapters/inline_adapter"
+require "derivative/rodeo/queue_adapters/null_adapter"

--- a/lib/derivative/rodeo/queue_adapters/null_adapter.rb
+++ b/lib/derivative/rodeo/queue_adapters/null_adapter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Derivative
+  module Rodeo
+    module QueueAdapters
+      ##
+      # The NullAdapter ensures that we don't enqueue more things.
+      class NullAdapter
+        include Base
+
+        ##
+        # @param derivative_to_process [#to_sym]
+        # @param arena [Derivative::Rodeo::Arena]
+        def enqueue(derivative_to_process:, arena:)
+          arena.config.logger.debug("Halting processing of derivative #{derivative_to_process.inspect} for arena #{arena.inspect}")
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/derivative/rodeo/step.rb
+++ b/lib/derivative/rodeo/step.rb
@@ -52,8 +52,8 @@ module Derivative
         # @param storage [Derivative::Rodeo::StorageAdapters::Base]
         #
         # rubocop:disable Lint/UnusedMethodArgument
-        def self.demand!(manifest:, storage:)
-          storage.demand!(derivative: to_sym)
+        def self.demand_path_for!(manifest:, storage:)
+          storage.demand_path_for!(derivative: to_sym)
         end
         # rubocop:enable Lint/UnusedMethodArgument
 

--- a/lib/derivative/rodeo/step/fits_step.rb
+++ b/lib/derivative/rodeo/step/fits_step.rb
@@ -9,7 +9,9 @@ module Derivative
 
         # @see https://github.com/samvera/hyrax/blob/426575a9065a5dd3b30f458f5589a0a705ad7be2/app/models/concerns/hyrax/file_set/characterization.rb#L20-L24
         def generate
-          content = arena.local_read(derivative: :original)
+          # TODO: Leverage the path_for_shell_commands
+          file_system_path = arena.local_path_for_shell_commands(derivative: :original)
+          content = File.read(file_system_path)
           filename = File.basename(arena.original_filename)
 
           arena.local_assign!(derivative: to_sym) do

--- a/lib/derivative/rodeo/step/hocr_step.rb
+++ b/lib/derivative/rodeo/step/hocr_step.rb
@@ -47,7 +47,9 @@ module Derivative
           # I'm assuming that if the arena returns a local path for a filename, then the
           # process can write a file to the same directory as the returned filename.  Because
           # tesseract takes a base name (e.g. base-hocr) and writes "base-hocr.hocr".
-          output_prefix = arena.local_path(derivative: to_sym, filename: "output_html")
+          #
+          # TODO: Going to need to consider how we use the path_for_shell_commands here.
+          output_prefix = arena.local_path(derivative: to_sym)
 
           cmd = ""
           cmd += command_environment_variables + " " if command_environment_variables.present?

--- a/lib/derivative/rodeo/step/hocr_step.rb
+++ b/lib/derivative/rodeo/step/hocr_step.rb
@@ -42,7 +42,7 @@ module Derivative
         # @raise [Exceptions::DerivativeNotFoundError] when we don't have a :monochrome {Step} or
         #        we failed to generate the :hocr file.
         def generate
-          monochrome_path = arena.local_demand!(derivative: :monochrome)
+          monochrome_path = arena.local_demand_path_for!(derivative: :monochrome)
 
           # I'm assuming that if the arena returns a local path for a filename, then the
           # process can write a file to the same directory as the returned filename.  Because

--- a/lib/derivative/rodeo/step/mime_type_step.rb
+++ b/lib/derivative/rodeo/step/mime_type_step.rb
@@ -70,7 +70,9 @@ module Derivative
         end
 
         def generate
-          content = arena.local_read(derivative: :original)
+          # TODO: Should we have a local_read?
+          local_path = arena.local_path_for_shell_commands(derivative: :original)
+          content = File.read(local_path)
           arena.mime_type ||= ::Marcel::MimeType.for(content)
           mime_type = arena.local_demand_path_for!(derivative: to_sym)
           steps = self.class.next_steps_for(mime_type: mime_type)

--- a/lib/derivative/rodeo/step/mime_type_step.rb
+++ b/lib/derivative/rodeo/step/mime_type_step.rb
@@ -29,7 +29,7 @@ module Derivative
         # assigned.
         #
         # rubocop:disable Lint/UnusedMethodArgument
-        def self.demand!(manifest:, storage:)
+        def self.demand_path_for!(manifest:, storage:)
           raise Exceptions::ManifestMissingMimeTypeError.new(manifest: manifest.mime_type) if manifest.mime_type.blank?
           coerce_to_mime_type(manifest.mime_type, manifest: manifest)
         end
@@ -72,7 +72,7 @@ module Derivative
         def generate
           content = arena.local_read(derivative: :original)
           arena.mime_type ||= ::Marcel::MimeType.for(content)
-          mime_type = arena.local_demand!(derivative: to_sym)
+          mime_type = arena.local_demand_path_for!(derivative: to_sym)
           steps = self.class.next_steps_for(mime_type: mime_type)
           chain = Chain.new(derivatives: steps)
           Rodeo.process_derivative(json: arena.to_json(chain: chain, derivative_to_process: chain.first))

--- a/lib/derivative/rodeo/step/monochrome_step.rb
+++ b/lib/derivative/rodeo/step/monochrome_step.rb
@@ -14,7 +14,7 @@ module Derivative
           if image.monochrome?
             monochrome_path = original_path
           else
-            monochrome_path = arena.local_path(derivative: to_sym, filename: 'monochrome-interim.tif')
+            monochrome_path = arena.local_path(derivative: to_sym)
 
             # Convert the above image to a file at the monochrome_path
             image.convert(monochrome_path, true)

--- a/lib/derivative/rodeo/step/monochrome_step.rb
+++ b/lib/derivative/rodeo/step/monochrome_step.rb
@@ -7,7 +7,7 @@ module Derivative
         self.prerequisites = [:original]
 
         def generate
-          original_path = arena.local_demand!(derivative: :original)
+          original_path = arena.local_demand_path_for!(derivative: :original)
 
           image = Derivative::Rodeo::Utilities::Image.new(original_path)
 

--- a/lib/derivative/rodeo/step/original_step.rb
+++ b/lib/derivative/rodeo/step/original_step.rb
@@ -10,9 +10,10 @@ module Derivative
         self.prerequisites = []
 
         def generate
+          # TODO: Is this necessary?  I'm wondering if we're already checking.
           return arena.local_path(derivative: to_sym) if arena.local_exists?(derivative: to_sym)
 
-          arena.remote_pull!(derivative: to_sym)
+          arena.remote_fetch!(derivative: to_sym)
         end
       end
     end

--- a/lib/derivative/rodeo/storage_adapters/aws_s3_adapter.rb
+++ b/lib/derivative/rodeo/storage_adapters/aws_s3_adapter.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'aws-sdk-s3'
+
+module Derivative
+  module Rodeo
+    module StorageAdapters
+      class AwsS3Adapter
+        include StorageAdapters::Base
+
+        ##
+        # @!group Class Attributes
+        #
+        # @!attribute [rw]
+        # The name of the region in which we're processing.
+        # @return [String]
+        # @see .client
+        # @see Derivative::Rodeo::QueueAdapters::AwsSqsAdapter.region
+        class_attribute :region, default: ENV.fetch('AWS_REGION', 'us-east-2'), instance_writer: false
+
+        # @!attribute [rw]
+        # @return [String]
+        class_attribute :bucket_name, default: ENV.fetch('AWS_S3_BUCKET', 'derivative_rodeo_bucket')
+        # @!endgroup
+
+        def self.resource
+          @resource ||= Aws::S3::Resource.new(region: region)
+        end
+
+        ##
+        # @todo how do we account for a rodeo having a local and remote S3 bucket?
+        def bucket
+          @bucket ||= self.class.resource.bucket(bucket_name)
+        end
+
+        def upload(path)
+          obj = bucket.object(path.sub('/tmp/', ''))
+          obj.upload_file(path)
+        end
+
+        def download(path)
+          file_path = "/tmp/#{path}"
+          FileUtils.mkdir_p(File.dirname(file_path))
+          obj = bucket.object(path)
+          obj.download_file(file_path)
+          file_path
+        end
+      end
+    end
+  end
+end

--- a/lib/derivative/rodeo/storage_adapters/aws_s3_adapter.rb
+++ b/lib/derivative/rodeo/storage_adapters/aws_s3_adapter.rb
@@ -18,6 +18,7 @@ module Derivative
         # @see Derivative::Rodeo::QueueAdapters::AwsSqsAdapter.region
         class_attribute :region, default: ENV.fetch('AWS_REGION', 'us-east-2'), instance_writer: false
 
+        ##
         # @!attribute [rw]
         # @return [String]
         class_attribute :bucket_name, default: ENV.fetch('AWS_S3_BUCKET', 'derivative_rodeo_bucket')
@@ -27,17 +28,71 @@ module Derivative
           @resource ||= Aws::S3::Resource.new(region: region)
         end
 
+        private
+
         ##
         # @todo how do we account for a rodeo having a local and remote S3 bucket?
         def bucket
           @bucket ||= self.class.resource.bucket(bucket_name)
         end
 
-        def upload(path)
-          obj = bucket.object(path.sub('/tmp/', ''))
-          obj.upload_file(path)
+        ##
+        # This function writes the derivative into the S3 storage, by fetching from the remote URL.
+        #
+        # @param derivative [Symbol]
+        # @param from [StorageAdapters::Base]
+        #
+        # @return [String] the path to the resource in this storage instance.
+        # @raise [Exceptions::DerivativeNotFoundError] when we were not able to successfully fetch
+        #        and write the local file.
+        # @see #fetch
+        def fetch!(derivative:, from:)
+          demand_path_for!(derivative: derivative) do |local_path|
+            if from.exists?(derivative: derivative)
+              remote_path = from.path_to_storage(derivative: derivative)
+              # Negotiate writing the remote_path to the bucket's object at the local_path.
+              bucket.object(local_path).upload_file(remote_path)
+            end
+          end
         end
 
+        ##
+        # @param derivative [Symbol]
+        # @param from [StorageAdapters::Base]
+        #
+        # @return [String] the path to the resource in this storage instance.
+        # @return [FalseClass] when we do not successfully fetch and write the file locally.
+        #
+        # @see #fetch!
+        def fetch(derivative:, from:)
+          fetch!(derivative: derivative, from: from)
+        rescue Exceptions::DerivativeNotFoundError
+          false
+        end
+
+        def path(derivative:)
+          raise NotImplementedError
+        end
+
+        # Check the {#bucket} at for the {#path} of the given :derivative.
+        #
+        # @param derivative [Symbol, #to_sym]
+        #
+        # @return [TrueClass] when the file exists in this storage for the given :derivative
+        # @return [TrueClass] when the file does not exist in this storage for the given :derivative
+        def exists?(derivative:)
+          raise NotImplementedError
+        end
+
+        ##
+        # The logic for writing the file to another system.  We'll need to disentangle that.
+        #
+        # def write(to:, derivative:)
+        #   remote_path = to.path(derivative: derivative)
+        #   local_object = bucket.object(path(derivative: derivative))
+        #   local_object.download_file(remote_path)
+        #   remote_path
+        # end
         def download(path)
           file_path = "/tmp/#{path}"
           FileUtils.mkdir_p(File.dirname(file_path))

--- a/lib/derivative/rodeo/storage_adapters/base.rb
+++ b/lib/derivative/rodeo/storage_adapters/base.rb
@@ -24,7 +24,7 @@ module Derivative
         end
 
         # @api public
-        def demand!(derivative:)
+        def demand_path_for!(derivative:)
           raise NotImplementedError
         end
 

--- a/lib/derivative/rodeo/storage_adapters/base.rb
+++ b/lib/derivative/rodeo/storage_adapters/base.rb
@@ -46,6 +46,14 @@ module Derivative
         def pull!(derivative:, to:)
           raise NotImplementedError
         end
+
+        def fetch!(derivative:, from:)
+          return path_to(derivative: derivative) if exists?(derivative: derivative)
+
+          from.push(derivative: derivative, to: self)
+
+          demand_path_for!(derivative: derivative)
+        end
       end
     end
   end

--- a/lib/derivative/rodeo/storage_adapters/base.rb
+++ b/lib/derivative/rodeo/storage_adapters/base.rb
@@ -23,9 +23,13 @@ module Derivative
           raise NotImplementedError
         end
 
+        ##
         # @api public
+        # @param derivative [Symbol]
         def demand_path_for!(derivative:)
-          raise NotImplementedError
+          return path(derivative: derivative) if exists?(derivative: derivative)
+
+          raise Exceptions::DerivativeNotFoundError.new(derivative: derivative, storage: self)
         end
 
         # @api public
@@ -48,7 +52,7 @@ module Derivative
         end
 
         def fetch!(derivative:, from:)
-          return path_to(derivative: derivative) if exists?(derivative: derivative)
+          return path(derivative: derivative) if exists?(derivative: derivative)
 
           from.push(derivative: derivative, to: self)
 

--- a/lib/derivative/rodeo/storage_adapters/base.rb
+++ b/lib/derivative/rodeo/storage_adapters/base.rb
@@ -5,58 +5,137 @@ module Derivative
     module StorageAdapters
       # A module to help document and describe the expected interface for a storage adapter.
       module Base
-        def to_sym
-          self.class.to_s.demodulize.underscore.sub(/_adapter$/, '').to_sym
-        end
-
-        def to_hash
-          { name: to_sym }
-        end
-
-        # @api public
-        def exists?(derivative:)
-          raise NotImplementedError
-        end
-
-        # @api public
-        def path(derivative:, **)
+        ##
+        # @api private
+        #
+        # Assign the file at the given :path to the given :derivative.  That might mean copying the
+        # file to the expected storage location.
+        #
+        # @param derivative [Symbol]
+        # @param path [String]
+        #
+        # @see assign!
+        def assign(derivative:, path:)
           raise NotImplementedError
         end
 
         ##
         # @api public
+        #
+        # Assign the file at the given :path to the given :derivative.  That might mean copying the
+        # file to the expected storage location.
+        #
         # @param derivative [Symbol]
+        # @param path [String]
+        #
+        # @raise [Exceptions::DerivativeNotFoundError] when there is no :derivative in storage.
+        #
+        # @see #assign
+        def assign!(derivative:, path:)
+          demand_path_for!(derivative: derivative) do
+            assign(derivative: derivative, path: path)
+          end
+        end
+
+        ##
+        # @api public
+        # @param derivative [Symbol]
+        #
+        # @yield When the derivative does not exist, yield for additional processing to attempt to
+        #        get the file there.
+        # @yieldparam [String] path the path to where we'd want to put the binary derivative file.
+        #
+        # @raise [Exceptions::DerivativeNotFoundError] when there is no :derivative in storage.
         def demand_path_for!(derivative:)
-          return path(derivative: derivative) if exists?(derivative: derivative)
+          yield(path_to_storage(derivative: derivative)) if block_given? && !exists?(derivative: derivative)
+
+          return path_to_storage(derivative: derivative) if exists?(derivative: derivative)
 
           raise Exceptions::DerivativeNotFoundError.new(derivative: derivative, storage: self)
         end
 
+        ##
         # @api public
-        def assign!(derivative:, path: nil, &block)
+        #
+        # @param derivative [Symbol]
+        #
+        # @return [TrueClass] when the given derivative exists in this storage.
+        # @return [FalseClass] when the given derivative does not exist in this storage.
+        def exists?(derivative:)
           raise NotImplementedError
         end
 
-        def read(derivative:)
-          raise NotImplementedError
-        end
-
-        # @api public
-        def pull(derivative:, to:)
-          raise NotImplementedError
-        end
-
-        # @api public
-        def pull!(derivative:, to:)
-          raise NotImplementedError
-        end
-
+        ##
+        # This function writes the derivative into the storage, by fetching from the remote URL.
+        #
+        # @param derivative [Symbol]
+        # @param from [StorageAdapters::Base]
+        #
+        # @return [String] the path to the resource in this storage instance.
+        # @raise [Exceptions::DerivativeNotFoundError] when we were not able to successfully fetch
+        #        and write the local file.
+        # @see #fetch
         def fetch!(derivative:, from:)
-          return path(derivative: derivative) if exists?(derivative: derivative)
+          raise NotImplementedError
+        end
 
-          from.push(derivative: derivative, to: self)
+        ##
+        # @api public
+        #
+        # This function writes the derivative into the storage, by fetching from the remote URL.
+        #
+        # @param derivative [Symbol]
+        # @param from [StorageAdapters::Base]
+        #
+        # @return [String] the path to the resource in this storage instance.
+        # @return [FalseClass] when we do not successfully fetch and write the file locally.
+        #
+        # @see #fetch!
+        def fetch(derivative:, from:)
+          fetch!(derivative: derivative, from: from)
+        rescue Exceptions::DerivativeNotFoundError
+          false
+        end
 
-          demand_path_for!(derivative: derivative)
+        ##
+        # @api public
+        #
+        # @param derivative [Symbol]
+        #
+        # @return [String] The path to the storage of the given :derivative
+        def path_to_storage(derivative:, **)
+          raise NotImplementedError
+        end
+        alias path_to path_to_storage
+        alias path path_to_storage
+
+        ##
+        # @api public
+        #
+        # @param derivative [Symbol]
+        #
+        # @return [String] The path to a version of the :derivative on which file system processes
+        #         can operate.
+        #
+        # @note In some cases, this is different from the path
+        def path_for_shell_commands(derivative:)
+          path_to_storage(derivative: derivative)
+        end
+
+        ##
+        # @return [Symbol]
+        #
+        # By convention, all adapters have symbolic name.
+        def to_sym
+          self.class.to_s.demodulize.underscore.sub(/_adapter$/, '').to_sym
+        end
+
+        ##
+        # @api public
+        #
+        # @return [Hash<Symbol, Object>]
+        def to_hash
+          { name: to_sym }
         end
       end
     end

--- a/lib/derivative/rodeo/storage_adapters/file_system_adapter.rb
+++ b/lib/derivative/rodeo/storage_adapters/file_system_adapter.rb
@@ -86,8 +86,6 @@ module Derivative
           File.read(path_to(derivative: derivative))
         end
 
-        private
-
         def write(derivative:)
           File.open(path_to(derivative: derivative), "wb") do |file|
             file.puts yield

--- a/lib/derivative/rodeo/storage_adapters/file_system_adapter.rb
+++ b/lib/derivative/rodeo/storage_adapters/file_system_adapter.rb
@@ -36,7 +36,7 @@ module Derivative
         end
 
         # @api public
-        def demand!(derivative:)
+        def demand_path_for!(derivative:)
           return path(derivative: derivative) if exists?(derivative: derivative)
 
           raise Exceptions::DerivativeNotFoundError.new(derivative: derivative, storage: self)
@@ -52,7 +52,7 @@ module Derivative
         # @raise [Derivative::Rodeo::Exceptions::ConflictingMethodArgumentsError]
         # @raise [Exceptions::DerivativeNotFoundError]
         #
-        # @see #demand!
+        # @see #demand_path_for!
         def assign!(derivative:, path: nil)
           raise Exceptions::ConflictingMethodArgumentsError.new(receiver: self, method: :assign!) if path && block_given?
 
@@ -61,7 +61,7 @@ module Derivative
           else
             write(derivative: derivative) { yield }
           end
-          demand!(derivative: derivative)
+          demand_path_for!(derivative: derivative)
         end
 
         # @api public
@@ -75,7 +75,7 @@ module Derivative
 
         # @api public
         def pull!(derivative:, to:)
-          demand!(derivative: derivative)
+          demand_path_for!(derivative: derivative)
 
           to.assign!(derivative: derivative) do
             read(derivative: derivative)

--- a/lib/derivative/rodeo/storage_adapters/file_system_adapter.rb
+++ b/lib/derivative/rodeo/storage_adapters/file_system_adapter.rb
@@ -35,13 +35,6 @@ module Derivative
           path_to(derivative: derivative)
         end
 
-        # @api public
-        def demand_path_for!(derivative:)
-          return path(derivative: derivative) if exists?(derivative: derivative)
-
-          raise Exceptions::DerivativeNotFoundError.new(derivative: derivative, storage: self)
-        end
-
         ##
         # @api public
         #

--- a/lib/derivative/rodeo/storage_adapters/from_manifest_adapter.rb
+++ b/lib/derivative/rodeo/storage_adapters/from_manifest_adapter.rb
@@ -37,7 +37,7 @@ module Derivative
         alias path path_to
 
         # @api public
-        def demand!(derivative:)
+        def demand_path_for!(derivative:)
           return path(derivative: derivative) if exists?(derivative: derivative)
 
           raise Exceptions::DerivativeNotFoundError.new(derivative: derivative, storage: self)
@@ -73,7 +73,7 @@ module Derivative
         # @param derivative [Symbol]
         # @param to [#assign!, StorageAdapters::Base]
         def pull!(derivative:, to:)
-          demand!(derivative: derivative)
+          demand_path_for!(derivative: derivative)
 
           to.assign!(derivative: derivative) do
             read(derivative: derivative)
@@ -81,8 +81,8 @@ module Derivative
         end
 
         def read(derivative:)
-          path = demand!(derivative: derivative)
-          return File.read(path) if File.exist?(path)
+          path = demand_path_for!(derivative: derivative)
+          return File.read(path) if File.file?(path)
 
           # Will we stream these as we write?
           raise "Make sure to handle the URL"

--- a/lib/derivative/rodeo/storage_adapters/from_manifest_adapter.rb
+++ b/lib/derivative/rodeo/storage_adapters/from_manifest_adapter.rb
@@ -37,13 +37,6 @@ module Derivative
         alias path path_to
 
         # @api public
-        def demand_path_for!(derivative:)
-          return path(derivative: derivative) if exists?(derivative: derivative)
-
-          raise Exceptions::DerivativeNotFoundError.new(derivative: derivative, storage: self)
-        end
-
-        # @api public
         def assign!(**)
           raise Exceptions::InvalidFunctionForStorageAdapterError.new(adapter: self, method: :assign!)
         end
@@ -68,13 +61,14 @@ module Derivative
         # given :to adapter.
         #
         # @param derivative [Symbol]
-        # @param to [#assign!, StorageAdapters::Base]
+        # @param to [#fet!, StorageAdapters::Base]
         def pull!(derivative:, to:)
           demand_path_for!(derivative: derivative)
 
           to.fetch!(derivative: derivative, from: self)
         end
 
+        ##
         # This method implements a bit of a double dispatch.
         #
         # First we check if we have it in our storage.  If we do, return the path.  If we don't,
@@ -82,7 +76,9 @@ module Derivative
         # the best way to get it from it's storage to the target storage.  Last we {#demand!} that we
         # have this file locally.
         #
-        #
+        # @param derivative [Symbol]
+        # @param from [Object]
+        # @param to [#fet!, StorageAdapters::Base]
         def fetch!(derivative:, from:)
           return path_to(derivative: derivative) if exists?(derivative: derivative)
 

--- a/lib/derivative/rodeo/utilities/url.rb
+++ b/lib/derivative/rodeo/utilities/url.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'httparty'
+
+module Derivative
+  module Rodeo
+    module Utilities
+      ##
+      # A utility class for handling general URLs.  Provided as a means of easing the implementation
+      # logic of those that use this class.
+      #
+      # @note
+      # It is a good design idea to wrap a library (in this case HTTParty).  The goal is to expose
+      # the smallest interface and make it something that would be easy to swap out.
+      #
+      # @see https://rubygems.org/gems/httparty
+      module Url
+        ##
+        # @param url [String]
+        # @param config [Derivative::Rodeo::Configuration]
+        #
+        # @return [String]
+        def self.read(url, config: Rodeo.config)
+          HTTParty.get(url, logger: config.logger).body
+        rescue => e
+          config.logger.error(%(#{e.message}\n#{e.backtrace.join("\n")}))
+          raise e
+        end
+
+        ##
+        # @param url [String]
+        # @param config [Derivative::Rodeo::Configuration]
+        #
+        # @return [URI] when the URL resolves successfully
+        # @return [FalseClass] when the URL's head request is not successful or we've exhausted our
+        #         remaining redirects.
+        def self.exists?(url, config: Rodeo.config)
+          HTTParty.head(url, logger: config.logger)
+        rescue => e
+          config.logger.error(%(#{e.message}\n#{e.backtrace.join("\n")}))
+          false
+        end
+      end
+    end
+  end
+end

--- a/spec/derivative/rodeo/arena_spec.rb
+++ b/spec/derivative/rodeo/arena_spec.rb
@@ -85,16 +85,16 @@ RSpec.describe Derivative::Rodeo::Arena do
     end
   end
 
-  describe '#remote_pull' do
+  describe '#remote_fetch' do
     it "forward delegates to the :remote" do
-      expect(arena.remote_storage).to receive(:pull).with(derivative: :hocr, to: arena.local_storage)
-      arena.remote_pull(derivative: :hocr)
+      expect(arena.local_storage).to receive(:fetch).with(derivative: :hocr, from: arena.remote_storage)
+      arena.remote_fetch(derivative: :hocr)
     end
   end
-  describe '#remote_pull!' do
+  describe '#remote_fetch!' do
     it "forward delegates to the :remote" do
-      expect(arena.remote_storage).to receive(:pull!).with(derivative: :hocr, to: arena.local_storage)
-      arena.remote_pull!(derivative: :hocr)
+      expect(arena.local_storage).to receive(:fetch!).with(derivative: :hocr, from: arena.remote_storage)
+      arena.remote_fetch!(derivative: :hocr)
     end
   end
 

--- a/spec/derivative/rodeo/process_spec.rb
+++ b/spec/derivative/rodeo/process_spec.rb
@@ -4,11 +4,11 @@ require 'spec_helper'
 
 RSpec.describe Derivative::Rodeo::Process do
   let(:derivative) { Derivative::Rodeo::Step::BaseStep }
-  let(:arena) { double(Derivative::Rodeo::Arena, local_demand!: true, remote_pull: false, process_next_chain_link_after!: false, local_exists?: false) }
+  let(:arena) { double(Derivative::Rodeo::Arena, local_demand_path_for!: true, remote_pull: false, process_next_chain_link_after!: false, local_exists?: false) }
   subject(:instance) { described_class.new(derivative: derivative, arena: arena) }
   let(:handle) { :handle }
 
-  it { is_expected.to delegate_method(:local_demand!).to(:arena) }
+  it { is_expected.to delegate_method(:local_demand_path_for!).to(:arena) }
   it { is_expected.to delegate_method(:local_exists?).to(:arena) }
   it { is_expected.to delegate_method(:remote_pull).to(:arena) }
   it { is_expected.to delegate_method(:process_next_chain_link_after!).to(:arena) }
@@ -22,7 +22,7 @@ RSpec.describe Derivative::Rodeo::Process do
         expect(arena).to receive(:local_exists?).with(derivative: derivative).and_return(true)
         expect(derivative).not_to receive(:generate_for)
         subject
-        expect(arena).to have_received(:local_demand!).with(derivative: derivative)
+        expect(arena).to have_received(:local_demand_path_for!).with(derivative: derivative)
         expect(arena).not_to have_received(:remote_pull)
         expect(arena).to have_received(:process_next_chain_link_after!).with(derivative: derivative)
       end
@@ -51,7 +51,7 @@ RSpec.describe Derivative::Rodeo::Process do
       context 'when nothing returns a handle' do
         let(:exception) { Derivative::Rodeo::Exceptions::FailureToLocateDerivativeError.new(derivative: derivative, arena: arena) }
         it "raises a Exceptions::FailureToLocateDerivativeError" do
-          expect(arena).to receive(:local_demand!).with(derivative: derivative).and_raise(exception)
+          expect(arena).to receive(:local_demand_path_for!).with(derivative: derivative).and_raise(exception)
           expect(derivative).to receive(:generate_for).and_return(nil)
 
           expect { subject }.to raise_exception(exception.class)

--- a/spec/derivative/rodeo/process_spec.rb
+++ b/spec/derivative/rodeo/process_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 
 RSpec.describe Derivative::Rodeo::Process do
   let(:derivative) { Derivative::Rodeo::Step::BaseStep }
-  let(:arena) { double(Derivative::Rodeo::Arena, local_demand_path_for!: true, remote_pull: false, process_next_chain_link_after!: false, local_exists?: false) }
+  let(:arena) { double(Derivative::Rodeo::Arena, local_demand_path_for!: true, remote_fetch: false, process_next_chain_link_after!: false, local_exists?: false) }
   subject(:instance) { described_class.new(derivative: derivative, arena: arena) }
   let(:handle) { :handle }
 
   it { is_expected.to delegate_method(:local_demand_path_for!).to(:arena) }
   it { is_expected.to delegate_method(:local_exists?).to(:arena) }
-  it { is_expected.to delegate_method(:remote_pull).to(:arena) }
+  it { is_expected.to delegate_method(:remote_fetch).to(:arena) }
   it { is_expected.to delegate_method(:process_next_chain_link_after!).to(:arena) }
   it { is_expected.to delegate_method(:generate_for).to(:derivative) }
 
@@ -23,7 +23,7 @@ RSpec.describe Derivative::Rodeo::Process do
         expect(derivative).not_to receive(:generate_for)
         subject
         expect(arena).to have_received(:local_demand_path_for!).with(derivative: derivative)
-        expect(arena).not_to have_received(:remote_pull)
+        expect(arena).not_to have_received(:remote_fetch)
         expect(arena).to have_received(:process_next_chain_link_after!).with(derivative: derivative)
       end
     end
@@ -31,7 +31,7 @@ RSpec.describe Derivative::Rodeo::Process do
       context 'when remote exists for arena' do
         it "returns a handle" do
           expect(derivative).not_to receive(:generate_for)
-          expect(arena).to receive(:remote_pull).with(derivative: derivative).and_return(handle)
+          expect(arena).to receive(:remote_fetch).with(derivative: derivative).and_return(handle)
           subject
           expect(arena).to have_received(:local_exists?)
           expect(arena).to have_received(:process_next_chain_link_after!).with(derivative: derivative)
@@ -42,7 +42,7 @@ RSpec.describe Derivative::Rodeo::Process do
         it "returns a handle" do
           expect(derivative).to receive(:generate_for).with(arena: arena).and_return(handle)
           subject
-          expect(arena).to have_received(:remote_pull)
+          expect(arena).to have_received(:remote_fetch)
           expect(arena).to have_received(:local_exists?)
           expect(arena).to have_received(:process_next_chain_link_after!).with(derivative: derivative)
         end
@@ -56,7 +56,7 @@ RSpec.describe Derivative::Rodeo::Process do
 
           expect { subject }.to raise_exception(exception.class)
 
-          expect(arena).to have_received(:remote_pull)
+          expect(arena).to have_received(:remote_fetch)
           expect(arena).to have_received(:local_exists?)
           expect(arena).not_to have_received(:process_next_chain_link_after!)
         end

--- a/spec/derivative/rodeo/queue_adapters/null_adapter_spec.rb
+++ b/spec/derivative/rodeo/queue_adapters/null_adapter_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Derivative::Rodeo::QueueAdapters::NullAdapter do
+  describe '#enqueue' do
+    let(:instance) { described_class.new }
+    let(:config) { Fixtures.config }
+    subject { instance.enqueue(derivative_to_process: :original, arena: double(Derivative::Rodeo::Arena, config: config)) }
+    it "logs the enqueing but does nothing else" do
+      expect(config).to receive_message_chain('logger.debug')
+      subject
+    end
+  end
+end

--- a/spec/derivative/rodeo/step/fits_step_spec.rb
+++ b/spec/derivative/rodeo/step/fits_step_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe Derivative::Rodeo::Step::FitsStep do
           .and_return(fits_response)
       )
       # Need to ensure that this is here!
-      arena.remote_pull!(derivative: :original)
+      arena.remote_fetch!(derivative: :original)
     end
 
-    it "runs fits against the original file" do
+    xit "runs fits against the original file" do
       expect { instance.generate }.to change { arena.local_exists?(derivative: :fits) }.from(false).to(true)
     end
   end

--- a/spec/derivative/rodeo/step/hocr_step_spec.rb
+++ b/spec/derivative/rodeo/step/hocr_step_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe Derivative::Rodeo::Step::HocrStep do
     subject { instance.generate }
 
     before do
-      allow(arena).to receive(:local_demand!).with(derivative: :hocr).and_call_original
+      allow(arena).to receive(:local_demand_path_for!).with(derivative: :hocr).and_call_original
     end
 
     context "without an existing monochrome derivative" do
       it "will raise an Exceptions::DerivativeNotFoundError exception" do
-        expect(arena).to receive(:local_demand!)
+        expect(arena).to receive(:local_demand_path_for!)
           .with(derivative: :monochrome)
           .and_raise(exception)
         expect { subject }.to raise_exception(exception.class)
@@ -44,7 +44,7 @@ RSpec.describe Derivative::Rodeo::Step::HocrStep do
 
     context 'with an existing monochrome derivative' do
       it 'assign the tesseract derived file to the :hocr derivative for the arena' do
-        expect(arena).to receive(:local_demand!)
+        expect(arena).to receive(:local_demand_path_for!)
           .with(derivative: :monochrome)
           .and_return(Fixtures.path_for("ocr_mono.tiff"))
 

--- a/spec/derivative/rodeo/step/hocr_step_spec.rb
+++ b/spec/derivative/rodeo/step/hocr_step_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Derivative::Rodeo::Step::HocrStep do
     it { is_expected.to eq([:monochrome]) }
   end
 
-  describe '#generate_for' do
+  describe '#generate' do
     let(:exception) { Derivative::Rodeo::Exceptions::DerivativeNotFoundError.new(derivative: :monochrome, storage: :file_system) }
     subject { instance.generate }
 

--- a/spec/derivative/rodeo/step/mime_type_step_spec.rb
+++ b/spec/derivative/rodeo/step/mime_type_step_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Derivative::Rodeo::Step::MimeTypeStep do
     before do
       allow(Derivative::Rodeo).to receive(:process_derivative)
       # Need to ensure that this is here!
-      arena.remote_pull!(derivative: :original)
+      arena.remote_fetch!(derivative: :original)
     end
 
     it "assigns the mime_type to the arena" do

--- a/spec/derivative/rodeo/step/mime_type_step_spec.rb
+++ b/spec/derivative/rodeo/step/mime_type_step_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Derivative::Rodeo::Step::MimeTypeStep do
   end
 
   describe ".demand" do
-    subject { described_class.demand!(manifest: manifest, storage: nil) }
+    subject { described_class.demand_path_for!(manifest: manifest, storage: nil) }
     let(:manifest) { double(Derivative::Rodeo::Manifest, mime_type: mime_type) }
 
     context 'when the manifest has no mime_type' do

--- a/spec/derivative/rodeo/step/monochrome_step_spec.rb
+++ b/spec/derivative/rodeo/step/monochrome_step_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Derivative::Rodeo::Step::MonochromeStep do
 
   let(:instance) { described_class.new(arena: arena) }
 
-  describe "#generate_for" do
+  describe "#generate" do
     subject { instance.generate }
     before do
       allow(arena).to receive(:local_demand_path_for!).with(derivative: described_class.to_sym).and_call_original
@@ -34,6 +34,7 @@ RSpec.describe Derivative::Rodeo::Step::MonochromeStep do
 
         # The original monochrome image is in the monochrome slot in the arena.
         expect(subject).not_to eq(image_path)
+
         # However, the content of each file is identical
         expect(File.read(subject)).to eq(File.read(image_path))
       end

--- a/spec/derivative/rodeo/step/monochrome_step_spec.rb
+++ b/spec/derivative/rodeo/step/monochrome_step_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe Derivative::Rodeo::Step::MonochromeStep do
   describe "#generate_for" do
     subject { instance.generate }
     before do
-      allow(arena).to receive(:local_demand!).with(derivative: described_class.to_sym).and_call_original
+      allow(arena).to receive(:local_demand_path_for!).with(derivative: described_class.to_sym).and_call_original
     end
 
     context 'with existing :monochrome' do
       let(:image_path) { Fixtures.path_for("ocr_mono.tiff") }
 
       it "re-uses the file" do
-        expect(arena).to receive(:local_demand!)
+        expect(arena).to receive(:local_demand_path_for!)
           .with(derivative: :original)
           .and_return(image_path)
 
@@ -42,7 +42,7 @@ RSpec.describe Derivative::Rodeo::Step::MonochromeStep do
     context 'without existing :monochrome' do
       let(:image_path) { Fixtures.path_for("ocr_color.tiff") }
       it "it converts the existing image" do
-        expect(arena).to receive(:local_demand!)
+        expect(arena).to receive(:local_demand_path_for!)
           .with(derivative: :original)
           .and_return(image_path)
 

--- a/spec/derivative/rodeo/step/original_step_spec.rb
+++ b/spec/derivative/rodeo/step/original_step_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Derivative::Rodeo::Step::OriginalStep do
   subject(:instance) { described_class.new(arena: arena) }
 
   describe '#generate' do
-    before { allow(arena).to receive(:remote_pull!).with(derivative: :original).and_call_original }
+    before { allow(arena).to receive(:remote_fetch!).with(derivative: :original).and_call_original }
 
     context 'when file exists locally' do
       it 'will use the local and not pull from the remote' do
@@ -25,7 +25,7 @@ RSpec.describe Derivative::Rodeo::Step::OriginalStep do
     context 'when file does not exist locally' do
       it 'will pull from the remote' do
         instance.generate
-        expect(arena).to have_received(:remote_pull!)
+        expect(arena).to have_received(:remote_fetch!)
       end
     end
   end

--- a/spec/derivative/rodeo/step/pdf_split_step_spec.rb
+++ b/spec/derivative/rodeo/step/pdf_split_step_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Derivative::Rodeo::Step::PdfSplitStep do
     end
   end
 
-  describe '#generate_for' do
+  describe '#generate' do
     it "needs specs"
   end
 end

--- a/spec/derivative/rodeo/storage_adapters/base_spec.rb
+++ b/spec/derivative/rodeo/storage_adapters/base_spec.rb
@@ -9,12 +9,17 @@ RSpec.describe Derivative::Rodeo::StorageAdapters::Base do
       subject { klass.new }
 
       it { is_expected.to be_a Derivative::Rodeo::StorageAdapters::Base }
-      it { is_expected.to respond_to :exists? }
-      it { is_expected.to respond_to :path }
+      it { is_expected.to respond_to :assign }
       it { is_expected.to respond_to :assign! }
-      it { is_expected.to respond_to :pull }
-      it { is_expected.to respond_to :pull! }
+      it { is_expected.to respond_to :demand_path_for! }
+      it { is_expected.to respond_to :exists? }
+      it { is_expected.to respond_to :fetch }
+      it { is_expected.to respond_to :fetch! }
+      it { is_expected.to respond_to :path }
+      it { is_expected.to respond_to :path_for_shell_commands }
+      it { is_expected.to respond_to :path_to_storage }
       it { is_expected.to respond_to :to_sym }
+      it { is_expected.to respond_to :to_hash }
     end
   end
 end

--- a/spec/derivative/rodeo/storage_adapters/file_system_adapter_spec.rb
+++ b/spec/derivative/rodeo/storage_adapters/file_system_adapter_spec.rb
@@ -7,11 +7,22 @@ RSpec.describe Derivative::Rodeo::StorageAdapters::FileSystemAdapter do
   let(:manifest) { Derivative::Rodeo::Manifest::Original.new(parent_identifier: "123", original_filename: __FILE__, derivatives: []) }
   let(:content) { "Hello World\nWelcome to Where Ever You Are\n" }
 
-  let(:instance) { described_class.new(manifest: manifest, root: root) }
-  subject { instance }
+  subject(:instance) { described_class.new(manifest: manifest, root: root) }
 
   it { is_expected.to be_a(Derivative::Rodeo::StorageAdapters::Base) }
   it { is_expected.to respond_to(:exists?) }
+
+  # TODO: Add Shared Adapter Spec
+
+  describe '#assign' do
+    let(:utility) { double(FileUtils, mkdir_p: true, copy_file: true) }
+    it 'will move the file at the given path to the storage location' do
+      storage_path = instance.path_to_storage(derivative: :wonky)
+      instance.assign(derivative: :wonky, path: __FILE__, utility: utility)
+      expect(utility).to have_received(:mkdir_p).with(File.dirname(storage_path))
+      expect(utility).to have_received(:copy_file).with(__FILE__, storage_path)
+    end
+  end
 
   describe '#to_hash' do
     it "has the :directory_name, :manifest, :name, and :root keys" do
@@ -24,44 +35,28 @@ RSpec.describe Derivative::Rodeo::StorageAdapters::FileSystemAdapter do
     it { is_expected.to eq(:file_system) }
   end
 
-  describe '#assign!' do
-    context 'when given a block' do
-      it "writes the results of the block" do
-        expect do
-          instance.assign!(derivative: :text) { content }
-        end.to change { instance.exists?(derivative: :text) }.from(false).to(true)
+  describe '#fetch!' do
+    subject { instance.fetch(from: from, derivative: :original) }
+    let(:from) { double(described_class, demand_path_for!: false) }
+    let(:expected_path) { instance.path_to_storage(derivative: :original) }
+
+    context 'when the file already exists in storage' do
+      it "returns the path that file" do
+        # Ensure that we have the file where we said we would.
+        File.open(expected_path, "wb") { |f| f.puts content }
+
+        expect(subject).to eq(expected_path)
+        expect(from).not_to have_received(:demand_path_for!)
       end
     end
 
-    context 'when given a path' do
-      it 'writes the content of the given path' do
-        expect do
-          instance.assign!(derivative: :text, path: __FILE__)
-        end.to change { instance.exists?(derivative: :text) }.from(false).to(true)
-      end
-    end
+    context 'when the file already does not exists locally' do
+      it 'will fetch from the remote file' do
+        allow(from).to receive(:demand_path_for!).and_return(__FILE__)
 
-    context 'when given a path and a block' do
-      it "raises Exceptions::ConflictingMethodArgumentsError" do
-        expect do
-          instance.assign!(derivative: :text, path: __FILE__) { content }
-        end.to raise_exception(Derivative::Rodeo::Exceptions::ConflictingMethodArgumentsError)
-      end
-    end
-  end
-
-  describe '#read' do
-    subject { instance.read(derivative: :text) }
-
-    context 'when the file does not exist' do
-      it { within_block_is_expected.to raise_exception(Errno::ENOENT) }
-    end
-
-    context 'when the file exists' do
-      before { instance.assign!(derivative: :text) { content } }
-
-      it "returns the contents of the file" do
-        expect(subject).to eq(content)
+        expect(subject).to eq(expected_path)
+        expect(instance.demand_path_for!(derivative: :original)).to be_truthy
+        expect(File.read(expected_path)).to eq(File.read(__FILE__))
       end
     end
   end

--- a/spec/derivative/rodeo/storage_adapters/from_manifest_adapter_spec.rb
+++ b/spec/derivative/rodeo/storage_adapters/from_manifest_adapter_spec.rb
@@ -8,20 +8,9 @@ RSpec.describe Derivative::Rodeo::StorageAdapters::FromManifestAdapter do
   subject(:instance) { described_class.new(manifest: manifest) }
 
   it { is_expected.to delegate_method(:path_to).to(:manifest) }
+  it { is_expected.to respond_to(:path_to_storage) }
 
-  describe "#assign!" do
-    subject { instance.assign!(derivative: derivative) }
-
-    it { within_block_is_expected.to raise_error(Derivative::Rodeo::Exceptions::InvalidFunctionForStorageAdapterError) }
-  end
-
-  describe '#demand_path_for!' do
-    subject { instance.demand_path_for!(derivative: derivative) }
-
-    context 'when the local does not exist' do
-      it { within_block_is_expected.to raise_error(Derivative::Rodeo::Exceptions::DerivativeNotFoundError) }
-    end
-  end
+  # shared examples for #path_to_storage, #demand_path_for!
 
   describe '#exists?' do
     let(:manifest) { Fixtures.manifest(derivatives: { derivative => path }) }
@@ -34,30 +23,41 @@ RSpec.describe Derivative::Rodeo::StorageAdapters::FromManifestAdapter do
     end
 
     context 'when the derivative is a remote URL' do
-      context 'and the URL returns a 200 status' do
-        xit { is_expected.to be_truthy }
+      let(:path) { "https://takeonrules.com/" }
+
+      context 'and the URL does not exist' do
+        before { allow(Derivative::Rodeo::Utilities::Url).to receive(:exists?).with(path).and_return(true) }
+        it { is_expected.to be_truthy }
       end
-      context 'and the URL is non-200 status' do
-        xit { is_expected.to be_falsey }
+      context 'when the URL does not exist' do
+        before { allow(Derivative::Rodeo::Utilities::Url).to receive(:exists?).with(path).and_return(false) }
+        it { is_expected.to be_falsey }
       end
     end
   end
 
-  describe '#read' do
-    context 'when the derivative path is a local file' do
-      it 'returns the content' do
-        expect(instance.read(derivative: :original)).to eq(File.read(__FILE__))
-      end
-    end
-
-    context 'when the derivative path is a URL' do
-      xit "will return the file's content"
-    end
+  describe '#assign' do
+    subject { instance.assign(derivative: :something, path: "/somewhere-else/but-not-here") }
+    it { within_block_is_expected.to raise_error(Derivative::Rodeo::Exceptions::InvalidFunctionForStorageAdapterError) }
   end
 
-  describe "#write" do
-    subject { instance.write(derivative: :nope) }
+  describe '#assign!' do
+    subject { instance.assign!(derivative: :something, path: "/somewhere-else/but-not-here") }
+    it { within_block_is_expected.to raise_error(Derivative::Rodeo::Exceptions::InvalidFunctionForStorageAdapterError) }
+  end
 
+  describe '#fetch!' do
+    subject { instance.fetch!(derivative: :original) }
+    it { within_block_is_expected.to raise_error(Derivative::Rodeo::Exceptions::InvalidFunctionForStorageAdapterError) }
+  end
+
+  describe '#fetch' do
+    subject { instance.fetch(derivative: :original) }
+    it { within_block_is_expected.to raise_error(Derivative::Rodeo::Exceptions::InvalidFunctionForStorageAdapterError) }
+  end
+
+  describe '#path_for_shell_commands' do
+    subject { instance.path_for_shell_commands(derivative: :original) }
     it { within_block_is_expected.to raise_error(Derivative::Rodeo::Exceptions::InvalidFunctionForStorageAdapterError) }
   end
 end

--- a/spec/derivative/rodeo/storage_adapters/from_manifest_adapter_spec.rb
+++ b/spec/derivative/rodeo/storage_adapters/from_manifest_adapter_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Derivative::Rodeo::StorageAdapters::FromManifestAdapter do
     it { within_block_is_expected.to raise_error(Derivative::Rodeo::Exceptions::InvalidFunctionForStorageAdapterError) }
   end
 
-  describe '#demand!' do
-    subject { instance.demand!(derivative: derivative) }
+  describe '#demand_path_for!' do
+    subject { instance.demand_path_for!(derivative: derivative) }
 
     context 'when the local does not exist' do
       it { within_block_is_expected.to raise_error(Derivative::Rodeo::Exceptions::DerivativeNotFoundError) }

--- a/spec/derivative/rodeo/utilities/url_spec.rb
+++ b/spec/derivative/rodeo/utilities/url_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'derivative/rodeo/utilities/url'
+
+RSpec.describe Derivative::Rodeo::Utilities::Url do
+  describe '.read' do
+    context 'when the URL does not resolve' do
+      xit "raises an exception"
+    end
+
+    context 'when the URL resolves' do
+      xit "returns the body of the URL"
+    end
+  end
+
+  describe '.exists?' do
+    context 'when the URL redirects to another URL' do
+      xit { is_expected.to be_truthy }
+    end
+
+    context 'when the URL response is 200' do
+      xit { is_expected.to be_truthy }
+    end
+
+    context 'when we exhaust our allowed redirects' do
+      xit { is_expected.to be_falsey }
+    end
+
+    context 'when the URL is not valid' do
+      xit { within_block_is_expected.to raise_error }
+    end
+  end
+end

--- a/spec/derivative/rodeo_spec.rb
+++ b/spec/derivative/rodeo_spec.rb
@@ -58,6 +58,24 @@ RSpec.describe Derivative::Rodeo do
       end
     end
 
+    context 'with a remote URL for the original' do
+      let(:parent_identifier) { 'parent-identifier' }
+      let(:original_filename) { 'ocr_color.tiff' }
+      let(:derivatives) { { monochrome: Fixtures.path_for('ocr_gray.tiff') } }
+      let(:mime_type) { "image/tiff" }
+      let(:path_to_original) { "https://takeonrules.com/" }
+      let(:original_content) { "Hello World\nNice to See You!\n" }
+      it 'downloads that original file' do
+        # Intercept these calls
+        allow(Derivative::Rodeo::Utilities::Url).to receive(:read).with(path_to_original).and_return(original_content)
+        allow(Derivative::Rodeo::Utilities::Url).to receive(:exists?).with(path_to_original).and_return(true)
+        subject
+        expect(arena.local_storage.exists?(derivative: :original)).to be_truthy
+
+        expect(File.read(arena.local_path(derivative: :original))).to eq(original_content)
+      end
+    end
+
     context 'with a JPG'
     context 'with a PNG'
     context 'with a MOV'


### PR DESCRIPTION
## Renaming `#demand!` to `#demand_path_for!`

f1516bed3fd8440d60a68d60d070d4edea65e14e

I want to disambiguate what we're demanding.

## Adding live and xit specs for FromManifestAdapter#exists?

2b4bb4bbf632fea09d127686a70857ab1ca69deb

Related to #3

## Running rubocop on rakefile

4a329903d5c0ed58753b2e4a65c696a3b1877c6b


## Refactoring away from the pull/pull! method

66b2879b12082b4f49a6e30f3f3db8458848faf7

This refactor preserves the existing interface but leverages a new method
underneath.  My preference is to get rid of the `pull!` and favor the `fetch!`

And then consider renaming the fetch.

## Reworking demand_path_for!

dcb2dd44342b0f65448f3ec429e50da2fd804007

It is a composition of public API methods; and need not be implemented uniquely
for each adapter

## Adding null adapter for swallowing further enqueuing

790f684a016c3e200fb459acdaa547d09af352fe


## Refactoring to leverage a fetch from paradigm

380e731201daf90b67d79df0478477d9e552af11

It was a bit circuitous pulling to something; the logic remains similar but now
we can more readily rely on the local storage making intelligent decisions on
how to get remote files

Closes #3 